### PR TITLE
Add support for passing get_options to #fetch

### DIFF
--- a/couchbase-jruby-client.gemspec
+++ b/couchbase-jruby-client.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'minitest',  '>= 5.1.0'
   s.add_development_dependency 'jrjackson', '>= 0.2.3'
   s.add_development_dependency 'pry'
+  s.add_development_dependency 'mocha'
 end

--- a/lib/couchbase/operations/fetch.rb
+++ b/lib/couchbase/operations/fetch.rb
@@ -20,10 +20,11 @@
 module Couchbase::Operations
   module Fetch
 
-    def fetch(key, set_options = {}, &block)
+    def fetch(key, set_options = {}, get_options = {}, &block)
       fail ArgumentError 'Must pass a block to #fetch' unless block_given?
 
-      get(key, quiet: false)
+      get_options[:quiet] = false
+      get(key, get_options)
     rescue Couchbase::Error::NotFound
       yield(block).tap {|value| set(key, value, set_options) }
     end

--- a/test/setup.rb
+++ b/test/setup.rb
@@ -19,6 +19,8 @@ gem 'minitest'
 require 'coveralls'
 Coveralls.wear!
 require 'minitest'
+gem 'mocha'
+require 'mocha/setup'
 require 'couchbase'
 require 'open-uri'
 require 'ostruct'

--- a/test/test_fetch.rb
+++ b/test/test_fetch.rb
@@ -37,6 +37,27 @@ class TestFetch < Minitest::Test
     assert_equal 'abc', cb.get(uniq_id)
   end
 
+  def test_can_include_get_options
+    cb.set(uniq_id, 'abc')
+
+    get_options = { extended: true }
+    value, _, cas = cb.fetch(uniq_id, {}, get_options) do
+      'unused'
+    end
+
+    assert_equal value, 'abc'
+    assert cas.is_a?(Fixnum)
+  end
+
+  def test_can_include_set_options
+    set_options = { ttl: 1 }
+
+    cb.expects(:set).with(uniq_id, 'abc', set_options)
+    cb.fetch(uniq_id, set_options) do
+      'abc'
+    end
+  end
+
   def test_fetch_works_with_quiet_mode
     cb.quiet = true
     cb.fetch(uniq_id) do


### PR DESCRIPTION
I wanted access to the CAS returned when you do a get with {extended: true}, so I added the ability to pass that in.
